### PR TITLE
vmlinuz icin checksum, kernel kaynagi icin fetch script

### DIFF
--- a/build/fetch-kernel-source.sh
+++ b/build/fetch-kernel-source.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Download the kernel source that matches the shipped vmlinuz.
+# Copyright (C) 2025 Radix Linux contributors
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST="$ROOT/kernel-linux/linux-6.16.1.tar.xz"
+URL="https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.16.1.tar.xz"
+
+if [[ -f "$DEST" ]]; then
+    echo "Zaten var: $DEST"
+    exit 0
+fi
+
+mkdir -p "$ROOT/kernel-linux"
+
+if command -v curl >/dev/null 2>&1; then
+    curl -fL "$URL" -o "$DEST"
+elif command -v wget >/dev/null 2>&1; then
+    wget -O "$DEST" "$URL"
+else
+    echo "curl ya da wget lazim. Elle indir: $URL" >&2
+    exit 1
+fi
+
+echo "Indirildi: $DEST"

--- a/build/kernel-build.sh
+++ b/build/kernel-build.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Kernel stage: verify shipped vmlinuz and require matching source.
+# Copyright (C) 2025 Radix Linux contributors
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VMLINUZ="$ROOT/kernel-linux/vmlinuz-6.16.1-radix"
+CHECKSUM="$ROOT/kernel-linux/vmlinuz-6.16.1-radix.sha256"
+SOURCE="$ROOT/kernel-linux/linux-6.16.1.tar.xz"
+
+if [[ ! -f "$VMLINUZ" ]]; then
+    echo "vmlinuz bulunamadi: $VMLINUZ" >&2
+    exit 1
+fi
+
+if [[ ! -f "$CHECKSUM" ]]; then
+    echo "checksum dosyasi yok, binary'ye kör güven olmaz" >&2
+    exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$ROOT/kernel-linux" && sha256sum -c "vmlinuz-6.16.1-radix.sha256")
+elif command -v shasum >/dev/null 2>&1; then
+    read -r expected _ < "$CHECKSUM"
+    actual="$(shasum -a 256 "$VMLINUZ" | awk '{print $1}')"
+    if [[ "$expected" != "$actual" ]]; then
+        echo "vmlinuz hash tutmuyor, birisi binary ile oynamis olabilir" >&2
+        exit 1
+    fi
+else
+    echo "sha256sum/shasum yok, checksum dogrulanamadi" >&2
+    exit 1
+fi
+
+if [[ ! -f "$SOURCE" ]]; then
+    echo "Binary dogru ama kernel kaynagi yok — GPL tarafi eksik." >&2
+    echo "Calistir: ./build/fetch-kernel-source.sh" >&2
+    exit 2
+fi
+
+echo "vmlinuz checksum OK, kernel kaynagi da yerinde. Derleme otomasyonu hala geliyor."

--- a/kernel-linux/vmlinuz-6.16.1-radix.sha256
+++ b/kernel-linux/vmlinuz-6.16.1-radix.sha256
@@ -1,0 +1,1 @@
+c7d6569dd87736e7dbe0f5648b15841b89ae5ee0bcee7a9c4b98059e135e1a77  vmlinuz-6.16.1-radix


### PR DESCRIPTION
## Ne oluyordu
Repoda vmlinuz var, config yok, hash yok. Guven mi?

## Ne yaptik
- vmlinuz SHA256 manifesti
- kernel-build.sh checksum dogruluyor, kaynak yoksa bagiriyor
- fetch-kernel-source.sh ile linux-6.16.1 indirilebilir

Made with [Cursor](https://cursor.com)